### PR TITLE
docs: replace faulty link

### DIFF
--- a/gitbook/validators/testnet.md
+++ b/gitbook/validators/testnet.md
@@ -174,7 +174,7 @@ to the network current block and you are safe to proceed to upgrade to a validat
 
 {% hint style="info" %}
 Validators and sentries can rapidly join the network with state-sync. See instructions for using
-state-sync [here](./gitbook/validators/state_sync.md).
+state-sync [here](./state_sync.md).
 {% endhint %}
 
 ## Upgrade to a validator


### PR DESCRIPTION
Replaced a faulty link.
[Before]( https://github.com/White-Whale-Defi-Platform/migaloo-docs/blob/main/gitbook/validators/gitbook/validators/state_sync.md)
[After](https://github.com/White-Whale-Defi-Platform/migaloo-docs/blob/main/gitbook/validators/state_sync.md)